### PR TITLE
修正：戦闘シーンにおけるリザルト画面の挙動をキー操作とタッチ操作で統一

### DIFF
--- a/SRPG_core.js
+++ b/SRPG_core.js
@@ -5787,7 +5787,7 @@ Game_Interpreter.prototype.unitAddState = function(eventId, stateId) {
                 SceneManager.pop();
                 this._phase = null;
             } else if (this._srpgBattleResultWindow.isChangeExp() == false &&
-                Input.isPressed('ok') || TouchInput.isPressed()) {
+                (Input.isPressed('ok') || TouchInput.isPressed())) {
                 this.endBattle(3);
             }
         } else {


### PR DESCRIPTION
はじめまして！
ツミオと申します。

戦闘シーンにおいて、リザルト画面の経験値ゲージの増加が終了してからendBattle()を実行できるようにするのが正しい挙動だと思うのですが、現在はマウス等のタッチ操作で連打した場合、すぐendBattle()を実行できてしまいます。
この部分を修正し、キー操作とタッチ操作で挙動を統一してみました。

一度問題がないか確認していただければなと思います！